### PR TITLE
Adding extra_jars (whatever extra lib jars you want) and metrics_callback (user-installed metrics callback) options to transactor.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ See `attributes/default.rb` for default values
 * `node[:datomic][:protocol]` = Transactor protocol to use
 * `node[:datomic][:ojdbc_jar_url]` = URL to download oracle jdbc jar
 * `node[:datomic][:ojdbc_jar_checksum]` = checksum for ojdbc jar
+* `node[:datomic][:extra_jars]` = Extra jars to install to the datomic/lib
+* `node[:datomic][:metrics_callback]` = Metrics function to set in transactor.properties
 * `node[:datomic][:sql_user]` = user to connect to sql database with
 * `node[:datomic][:sql_password]` = password to connect to sql database with
 * `node[:datomic][:sql_url]` = sql database connection string

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,11 +9,14 @@ default[:datomic][:jmx_port] = 5111
 
 default[:datomic][:ojdbc_jar_url] = nil
 default[:datomic][:ojdbc_jar_checksum] = nil
+default[:datomic][:extra_jars] = nil
 default[:datomic][:sql_user] = nil
 default[:datomic][:sql_password] = nil
 default[:datomic][:sql_url] = nil
 
 default[:datomic][:datomic_license_key] = nil
+
+default[:datomic][:metrics_callback] = nil
 
 default[:datomic][:java][:'-X'][:ms] = '4g'
 default[:datomic][:java][:'-X'][:mx] = '4g'

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -27,6 +27,17 @@ action :install do
 
   protocol = node[:datomic][:protocol]
 
+  if node[:datomic][:extra_jars]
+    for jar in node[:datomic][:extra_jars]
+      jar_name = (jar.split /\//) [-1]
+      remote_file "#{datomic_run_dir}/lib/#{jar_name}" do
+        source jar
+        owner username
+        group username
+      end
+    end
+  end
+
   if(protocol == 'sql')
     ojdbc_jar_url = node[:datomic][:ojdbc_jar_url]
 
@@ -61,7 +72,8 @@ action :install do
       :memcached_hosts => node[:datomic][:memcached_hosts],
       :memory_index_threshold => node[:datomic][:memory_index_threshold],
       :memory_index_max => node[:datomic][:memory_index_max],
-      :object_cache_max => node[:datomic][:object_cache_max]
+      :object_cache_max => node[:datomic][:object_cache_max],
+      :metrics_callback => node[:datomic][:metrics_callback]
     })
   end
 
@@ -88,7 +100,7 @@ action :install do
     start_retries node[:datomic][:start_retries]
     start_delay node[:datomic][:start_delay]
     start_check Proc.new { Mixlib::ShellOut.new("netstat -tunl | grep -- #{node[:datomic][:jmx_port]}").run_command.stdout =~ /LISTEN/ }
-  end
+ end
 
   java_service 'datomic' do
     action :restart

--- a/templates/default/transactor.properties.erb
+++ b/templates/default/transactor.properties.erb
@@ -20,3 +20,8 @@ read-concurrency=<%= @read_concurrency %>
 <% if(@memcached_hosts) %>
 memcached=<%= @memcached_hosts %>
 <% end %>
+
+<% if(@metrics_callback) %>
+metrics-callback=<%=@metrics_callback%>
+<% end %>
+

--- a/test/unit/providers/sql_protocol_spec.rb
+++ b/test/unit/providers/sql_protocol_spec.rb
@@ -59,6 +59,7 @@ describe 'datomic::default' do
            memcached_hosts: "rad-host:1234",
            memory_index_threshold: memory_index_threshold,
            memory_index_max: memory_index_max,
+           metrics_callback: nil,
            object_cache_max: object_cache_max
          }
       )


### PR DESCRIPTION
This will enable us to inject our user function for metrics translation to JMX.  Stay tuned for the bagboy_datomic pull request too.
