### PR TITLE
Ignoring a single instance of a foodcritic error

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -27,7 +27,7 @@ action :install do
 
   protocol = node[:datomic][:protocol]
 
-  if node[:datomic][:extra_jars]
+  if node[:datomic][:extra_jars] # ~FC023
     for jar in node[:datomic][:extra_jars]
       jar_name = (jar.split /\//) [-1]
       remote_file "#{datomic_run_dir}/lib/#{jar_name}" do


### PR DESCRIPTION
Sorry - should have run the whole suite - didn't.  We're ignoring this FC error because we have an array of things, not a single thing.
