### PR TITLE
This forcibly adds compression to logrotation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,8 @@ default[:datomic][:java][:'-D'][:'com.sun.management.jmxremote.authenticate'] = 
 default[:datomic][:concurrency][:write] = 4
 default[:datomic][:concurrency][:read] = 8
 
+default[:datomic][:compress_log_files] = true
+
 default[:datomic][:memcached_hosts] = nil
 
 default[:datomic][:start_retries] = 200

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -89,6 +89,16 @@ action :install do
     notifies :stop, 'datomic[stop datomic in preparation for start or restart]', :immediately
   end
 
+  template "#{temporary_zip_dir}/bin/logback.xml" do
+    source 'logback.xml.erb'
+    owner username
+    group username
+    cookbook 'datomic'
+    mode 0644
+    variables :compress_log_files => node[:datomic][:compress_log_files]
+    notifies :stop, 'datomic[stop datomic in preparation for start or restart]', :immediately
+  end
+
   if node[:datomic][:service_install]
     run_dir = temporary_zip_dir # assign so that it can be passed into the proc
     java_service 'configure datomic' do

--- a/templates/default/logback.xml.erb
+++ b/templates/default/logback.xml.erb
@@ -1,0 +1,69 @@
+<configuration>
+
+  <!-- prevent per-message overhead for jul logging calls, e.g. Hornet -->
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+    <resetJUL>true</resetJUL>
+  </contextListener>
+
+  <appender name="MAIN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+<% if @compress_log_files %>
+      <fileNamePattern>${DATOMIC_LOG_DIR:-log}/%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+      <maxHistory>72</maxHistory>
+    </rollingPolicy>
+    <prudent>false</prudent> <!-- can't prudent with compression -->
+<% else %>
+      <fileNamePattern>${DATOMIC_LOG_DIR:-log}/%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>72</maxHistory>
+    </rollingPolicy>
+    <prudent>true</prudent> <!-- multi jvm safe, slower -->
+<% end %>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %-10contextName %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- uncomment to log storage access -->
+  <!-- <logger name="datomic.kv-cluster" level="DEBUG"/> -->
+
+  <!-- uncomment to log transactor heartbeat -->
+  <!-- <logger name="datomic.lifecycle" level="DEBUG"/> -->
+
+  <!-- uncomment to log transactions (transactor side) -->
+  <!-- <logger name="datomic.transaction" level="DEBUG"/> -->
+
+  <!-- uncomment to log transactions (peer side) -->
+  <!-- <logger name="datomic.peer" level="DEBUG"/> -->
+
+  <!-- uncomment to log the transactor log -->
+  <!-- <logger name="datomic.log" level="DEBUG"/> -->
+
+  <!-- uncomment to log peer connection to transactor -->
+  <!-- <logger name="datomic.connector" level="DEBUG"/> -->
+
+  <!-- uncomment to log storage gc -->
+  <!-- <logger name="datomic.garbage" level="DEBUG"/> -->
+
+  <!-- uncomment to log indexing jobs -->
+  <!-- <logger name="datomic.index" level="DEBUG"/> -->
+
+  <!-- these namespsaces create a ton of log noise -->
+  <logger name="httpclient" level="INFO"/>
+  <logger name="org.apache.commons.httpclient" level="INFO"/>
+  <logger name="org.apache.http" level="INFO"/>
+  <logger name="org.jets3t" level="INFO"/>
+  <logger name="com.amazonaws" level="INFO"/>
+  <logger name="com.amazonaws.request" level="WARN"/>
+  <logger name="sun.rmi" level="INFO"/>
+  <logger name="net.spy.memcached" level="INFO"/>
+  <logger name="com.couchbase.client" level="INFO"/>
+  <logger name="org.apache.zookeeper" level="INFO"/>
+  <logger name="com.ning.http.client.providers.netty" level="INFO"/>
+  <logger name="org.eclipse.jetty" level="INFO"/>
+  <logger name="org.hornetq.core.client.impl" level="INFO"/>
+  <logger name="org.apache.tomcat.jdbc.pool" level="INFO"/>
+
+  <root level="info">
+    <appender-ref ref="MAIN"/>
+  </root>
+</configuration>

--- a/test/integration/install/serverspec/default_spec.rb
+++ b/test/integration/install/serverspec/default_spec.rb
@@ -9,4 +9,9 @@ describe 'datomic::default' do
     its(:exit_status) { should eq(0) }
     its(:stdout) { should match(/datomic-free-transactor-0\.8\.4215/) }
   end
+
+  describe file('/home/datomic/datomic-free-0.8.4215/bin/logback.xml') do
+    its(:content) { should match ".log.gz" }
+    its(:content) { should match "<prudent>false" }
+  end
 end


### PR DESCRIPTION
- Based on logback documentation used by datomic
- utilizes attribute which is true by default
- Note I'm not sure the best way to test this without leaving a test kitchen
  instance running overnight
